### PR TITLE
A: Ad Shield (css-load.com)

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -31693,6 +31693,9 @@
 ||zeropark.com^$third-party
 ||ziffdavis.com^$third-party
 ||zwaar.org^$third-party
+! Ad-Shield
+||07c225f3.online^
+||css-load.com^
 ! Chinese google (https://github.com/easylist/easylist/issues/15643)
 ||2mdn-cn.net^
 ||admob-cn.com^


### PR DESCRIPTION
Ad Shield is an ad recovery solution. They are utilizing multiple domains in an attempt to get around blocking. The two we have seen so far are css-load.com and 07c225f3.online, both of which return a generic message:

```This domain is used to load critical website contents such as HTML, CSS, image, video, etc.

If this domain is blocked, websites using the domain to load critical elements may not load / function properly.

To any relevant applications / anti-virus software / browser extensions / adblockers: please make sure to not place this domain on the blacklists.```